### PR TITLE
Bump version and update dependencies to v0.0.15-alpha

### DIFF
--- a/.cloud/docker/Dockerfile
+++ b/.cloud/docker/Dockerfile
@@ -5,7 +5,7 @@ ARG USERNAME=codeclarity
 ARG PLUGINNAME=plugin
 
 # DEV IMAGE
-FROM golang:1.24.3-alpine AS plugin-dev
+FROM golang:1.24.4-alpine AS plugin-dev
 ARG KIND
 ARG PLUGINNAME
 WORKDIR /codeclarity/${KIND}/${PLUGINNAME}
@@ -15,7 +15,7 @@ RUN go install github.com/air-verse/air@latest
 CMD ["air", "-c", ".air.toml"]
 
 # DEBUG IMAGE
-FROM golang:1.24.3-alpine AS plugin-debug
+FROM golang:1.24.4-alpine AS plugin-debug
 ARG KIND
 ARG PLUGINNAME
 ENV KIND=${KIND}
@@ -29,7 +29,7 @@ CMD ["/go/bin/dlv", "debug", ".", "--headless", "--listen=:40000", "--accept-mul
 
 
 # BUILD IMAGE
-FROM golang:1.24.3-alpine AS plugin-build
+FROM golang:1.24.4-alpine AS plugin-build
 ARG KIND
 ARG PLUGINNAME
 COPY . /codeclarity/${KIND}/${PLUGINNAME}

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
     "name": "knowledge",
-    "version": "v0.0.14-alpha",
+    "version": "v0.0.15-alpha",
     "image_name": "codeclarityce/service-knowledge",
     "depends_on": []
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/CodeClarityCE/service-knowledge
 go 1.24.3
 
 require (
-	github.com/CodeClarityCE/utility-dbhelper v0.0.6-alpha
+	github.com/CodeClarityCE/utility-dbhelper v0.0.7-alpha
 	github.com/CodeClarityCE/utility-node-semver v0.0.5-alpha
 	github.com/CodeClarityCE/utility-types v0.0.10-alpha
 	github.com/schollz/progressbar/v3 v3.18.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/CodeClarityCE/utility-dbhelper v0.0.6-alpha h1:SxZApXen0QyPY2cwtEz42TDDIyugDJ+8I3vXskq9myE=
-github.com/CodeClarityCE/utility-dbhelper v0.0.6-alpha/go.mod h1:RkdJC0IEfUMrIRhmKUWK74gC+jg9O+gFyT2K4Gx4Z2E=
+github.com/CodeClarityCE/utility-dbhelper v0.0.7-alpha h1:V7wx85z9yPDnOh54U5+mOaYT2JEC2TeSWL2Ii32ASw4=
+github.com/CodeClarityCE/utility-dbhelper v0.0.7-alpha/go.mod h1:xCuw72RlrTrcHp1Kq5rjb1pCHRZRGDSoIdTlgxC7QIY=
 github.com/CodeClarityCE/utility-node-semver v0.0.5-alpha h1:CaFjvEriq3NNS5WcCf0EewV+LTdEQrFu3oQ1eIkpcm0=
 github.com/CodeClarityCE/utility-node-semver v0.0.5-alpha/go.mod h1:P0HHIagqW3xceAfb50nMumNyw2U4iKi11IZIYKc11L4=
 github.com/CodeClarityCE/utility-types v0.0.10-alpha h1:tuR1urE8rCq9jsidN6UnIFhjySYUUTtBaPqmQFf7wTw=


### PR DESCRIPTION
Update the project version to v0.0.15-alpha, upgrade the base image to golang:1.24.4-alpine, and improve the utility-dbhelper dependency to v0.0.7-alpha.